### PR TITLE
Config coordorder

### DIFF
--- a/Resources/views/Form/yandexMaps.html.twig
+++ b/Resources/views/Form/yandexMaps.html.twig
@@ -5,7 +5,7 @@
         {% block unno_yandex_maps_html %}
             <div id="{{ id }}_canvas"></div>
 
-            <script src="http://api-maps.yandex.ru/2.0-stable/?load=package.standard&lang=ru-RU" type="text/javascript"></script>
+            <script src="http://api-maps.yandex.ru/2.0-stable/?coordorder=longlat&load=package.standard&lang=ru-RU" type="text/javascript"></script>
             <script type="text/javascript">
                 ymaps.ready(function () {
                     var canvas = document.getElementById('{{ id }}_canvas'),


### PR DESCRIPTION
https://tech.yandex.ru/maps/doc/jsapi/2.1/dg/concepts/load-docpage/#coordorder
Указал явно порядок географических координат

В шаблон координаты указанны в порядке: долгота, широта.
Яндекс API по умолчанию работает с иным порядком: широта, долгота.

Например, вот этот кусок кода из шаблона несовместим с настройкам по умолчанию:
center = [
{{ form.vars.value and form.vars.value.longitude ? form.vars.value.longitude : longitude }},
{{ form.vars.value and form.vars.value.latitude ? form.vars.value.latitude : latitude }}
],
