### PR TITLE
Behaviors

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -45,6 +45,9 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('typeSelector')->defaultValue(false)->end()
                     ->end()
                 ->end()
+                ->arrayNode('behaviors')
+                    ->prototype('scalar')
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/UnnoYandexMapsExtension.php
+++ b/DependencyInjection/UnnoYandexMapsExtension.php
@@ -38,6 +38,8 @@ class UnnoYandexMapsExtension extends Extension
         $container->setParameter('unno_yandex_maps.controls.scaleLine', $config['controls']['scaleLine']);
         $container->setParameter('unno_yandex_maps.controls.miniMap', $config['controls']['miniMap']);
         $container->setParameter('unno_yandex_maps.controls.typeSelector', $config['controls']['typeSelector']);
+
+        $container->setParameter('unno_yandex_maps.behaviors', $config['behaviors']);
     }
 
     public function getAlias()

--- a/Form/YandexMapsType.php
+++ b/Form/YandexMapsType.php
@@ -55,6 +55,8 @@ class YandexMapsType extends AbstractType
         $view->vars['hasControlsTypeSelector'] = $options['hasControlsTypeSelector'];
         $view->vars['hasControlsMiniMap']      = $options['hasControlsMiniMap'];
         $view->vars['hasControlsScaleLine']    = $options['hasControlsScaleLine'];
+
+        $view->vars['behaviors'] = $options['behaviors'];
     }
     
     /**
@@ -73,6 +75,8 @@ class YandexMapsType extends AbstractType
             'placemark'                 => $this->container->hasParameter('unno_yandex_maps.placemark') ? $this->container->getParameter('unno_yandex_maps.placemark') : false,
             'placemarkDraggable'        => $this->container->hasParameter('unno_yandex_maps.placemark.draggable') ? $this->container->getParameter('unno_yandex_maps.placemark.draggable') : false,
             'placemarkGeocoderFunction' => $this->container->hasParameter('unno_yandex_maps.placemark.geocoderFunction') ? $this->container->getParameter('unno_yandex_maps.placemark.geocoderFunction') : false,
+
+            'behaviors'                 => $this->container->hasParameter('unno_yandex_maps.behaviors') ? $this->container->getParameter('unno_yandex_maps.behaviors') : array(),
 
             'hasControlsZoom'           => $this->container->hasParameter('unno_yandex_maps.controls.zoom') ? $this->container->getParameter('unno_yandex_maps.controls.zoom') : false,
             'hasControlsZoomSmall'      => $this->container->hasParameter('unno_yandex_maps.controls.zoomSmall') ? $this->container->getParameter('unno_yandex_maps.controls.zoomSmall') : false,

--- a/Resources/views/Form/yandexMaps.html.twig
+++ b/Resources/views/Form/yandexMaps.html.twig
@@ -5,7 +5,7 @@
         {% block unno_yandex_maps_html %}
             <div id="{{ id }}_canvas"></div>
 
-            <script src="http://api-maps.yandex.ru/2.0-stable/?coordorder=longlat&load=package.standard&lang=ru-RU" type="text/javascript"></script>
+            <script src="http://api-maps.yandex.ru/2.0-stable/?coordorder=longlat&load={{ package }}&lang=ru-RU" type="text/javascript"></script>
             <script type="text/javascript">
                 ymaps.ready(function () {
                     var canvas = document.getElementById('{{ id }}_canvas'),
@@ -21,6 +21,7 @@
 
                     map = new ymaps.Map(canvas, {
                         center: center,
+                        behaviors: {{ behaviors|json_encode()|raw }},
                         zoom: zoom
                     });
 

--- a/Resources/views/Form/yandexMaps.html.twig
+++ b/Resources/views/Form/yandexMaps.html.twig
@@ -5,7 +5,7 @@
         {% block unno_yandex_maps_html %}
             <div id="{{ id }}_canvas"></div>
 
-            <script src="http://api-maps.yandex.ru/2.0-stable/?coordorder=longlat&load={{ package }}&lang=ru-RU" type="text/javascript"></script>
+            <script src="http://api-maps.yandex.ru/2.0-stable/?coordorder=longlat&load=package.standard&lang=ru-RU" type="text/javascript"></script>
             <script type="text/javascript">
                 ymaps.ready(function () {
                     var canvas = document.getElementById('{{ id }}_canvas'),


### PR DESCRIPTION
Добавил возможность конфигурировать behaviors (поведения модуля).
Например, в конфиге можно указать:

```
unno_yandex_maps:
    behaviors:
       # перемещение карты мышкой 
        - drag 
       # масштабирование с помощью колесика мышки
        - scrollZoom # масштабирование с помощью колесика мышки
```

https://tech.yandex.ru/maps/doc/jsapi/2.0/ref/reference/map.behavior.Manager-docpage/#param-behaviors
